### PR TITLE
Disable MacOS from the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         database:
+          - 2017
           - 2019
           - 2022
           - azure-sql-edge
@@ -187,40 +188,30 @@ jobs:
         shell: powershell
         run: cargo test ${{matrix.features}}
 
-  cargo-test-macos:
-    runs-on: macos-15
+  # cargo-test-macos:
+  #   runs-on: macos-15
 
-    strategy:
-      fail-fast: false
-      matrix:
-        database:
-          - 2019
-        features:
-          - "--no-default-features --features=rustls,chrono,time,tds73,sql-browser-async-std,sql-browser-tokio,sql-browser-smol,integrated-auth-gssapi,rust_decimal,bigdecimal"
-          - "--no-default-features --features=vendored-openssl"
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       database:
+  #         - 2019
+  #       features:
+  #         - "--no-default-features --features=rustls,chrono,time,tds73,sql-browser-async-std,sql-browser-tokio,sql-browser-smol,integrated-auth-gssapi,rust_decimal,bigdecimal"
+  #         - "--no-default-features --features=vendored-openssl"
 
-    env:
-      TIBERIUS_TEST_CONNECTION_STRING: "server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;TrustServerCertificate=true"
+  #   env:
+  #     TIBERIUS_TEST_CONNECTION_STRING: "server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;TrustServerCertificate=true"
 
-    # steps:
-    #   - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-    #   - uses: actions-rs/toolchain@v1
+  #     - uses: actions-rs/toolchain@v1
 
-    #   - name: Install Docker on macOS
-    #     if: runner.os == 'macOS'
-    #     shell: bash
-    #     run: |
+  #     - uses: docker-practice/actions-setup-docker@master
 
-    #       # Install Docker CLI
-    #       brew install docker colima
-    #       colima start
-    #       # Verify installation
-    #       docker --version
-    #       docker info
+  #     - name: Start SQL Server ${{matrix.database}}
+  #       run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d mssql-${{matrix.database}}
 
-    #   - name: Start SQL Server ${{matrix.database}}
-    #     run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d mssql-${{matrix.database}}
-
-    #   - name: Run tests
-    #     run: cargo test ${{matrix.features}}
+  #     - name: Run tests
+  #       run: cargo test ${{matrix.features}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
       - uses: docker-practice/actions-setup-docker@master
 
       - name: Start SQL Server ${{matrix.database}}
-        run: DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml up -d mssql-${{matrix.database}}
+        run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d mssql-${{matrix.database}}
 
       - name: Run tests
         run: cargo test ${{matrix.features}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,8 +214,8 @@ jobs:
         run: |
 
           # Install Docker CLI
-          brew install docker
-
+          brew install docker colima
+          colima start
           # Verify installation
           docker --version
           docker info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,17 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
 
-      - uses: docker-practice/actions-setup-docker@master
+      - name: Install Docker on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+
+          # Install Docker CLI
+          brew install docker
+
+          # Verify installation
+          docker --version
+          docker info
 
       - name: Start SQL Server ${{matrix.database}}
         run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d mssql-${{matrix.database}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,25 +202,25 @@ jobs:
     env:
       TIBERIUS_TEST_CONNECTION_STRING: "server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;TrustServerCertificate=true"
 
-    steps:
-      - uses: actions/checkout@v2
+    # steps:
+    #   - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+    #   - uses: actions-rs/toolchain@v1
 
-      - name: Install Docker on macOS
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
+    #   - name: Install Docker on macOS
+    #     if: runner.os == 'macOS'
+    #     shell: bash
+    #     run: |
 
-          # Install Docker CLI
-          brew install docker colima
-          colima start
-          # Verify installation
-          docker --version
-          docker info
+    #       # Install Docker CLI
+    #       brew install docker colima
+    #       colima start
+    #       # Verify installation
+    #       docker --version
+    #       docker info
 
-      - name: Start SQL Server ${{matrix.database}}
-        run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d mssql-${{matrix.database}}
+    #   - name: Start SQL Server ${{matrix.database}}
+    #     run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d mssql-${{matrix.database}}
 
-      - name: Run tests
-        run: cargo test ${{matrix.features}}
+    #   - name: Run tests
+    #     run: cargo test ${{matrix.features}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          - 2017
           - 2019
           - 2022
           - azure-sql-edge


### PR DESCRIPTION
docker-compose is not a command anymore on GH runners. Its `docker compose` 
The hyphen was removed. 

This may uncover problems on MacOS after unblocking the bad command.

Aspires to fix https://github.com/saurabh500/tiberius/issues/6?issue=saurabh500%7Ctiberius%7C9